### PR TITLE
Potential fix for code scanning alert no. 13: Database query built from user-controlled sources

### DIFF
--- a/apps/auth-api/src/app/user/user.service.ts
+++ b/apps/auth-api/src/app/user/user.service.ts
@@ -16,12 +16,21 @@ export class UserService {
 
   async findOneByUsernamePassword(username: string, password: string) {
     return this.userModel
-      .findOne({ username, password }, { password: 0 })
+      .findOne(
+        {
+          username: { $eq: username },
+          password: { $eq: password },
+        },
+        { password: 0 },
+      )
       .lean()
       .exec();
   }
 
   async findOne(username: string) {
-    return this.userModel.findOne({ username }, { password: 0 }).lean().exec();
+    return this.userModel
+      .findOne({ username: { $eq: username } }, { password: 0 })
+      .lean()
+      .exec();
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/sh977218/nx-workspace/security/code-scanning/13](https://github.com/sh977218/nx-workspace/security/code-scanning/13)

The safest fix here is to prevent user-controlled values from being interpreted as query operators by wrapping them in MongoDB’s `$eq` operator (and optionally validating primitive type). This keeps existing behavior (exact username/password match) while neutralizing operator injection.

Best targeted change (without altering functionality): in `apps/auth-api/src/app/user/user.service.ts`, update:
- `findOneByUsernamePassword` query from `{ username, password }` to:
  `{ username: { $eq: username }, password: { $eq: password } }`
- `findOne` query from `{ username }` to:
  `{ username: { $eq: username } }`

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
